### PR TITLE
Header logo to use relative path

### DIFF
--- a/client/components/header.js
+++ b/client/components/header.js
@@ -6,7 +6,7 @@ export const Header = React.createClass({
   render () {
     return (
       <header className="container-fluid mtb txt-center" role="banner">
-        <a href="http://nodezoo.com" className="logo logo-nodezoo"></a>
+        <a href="/" className="logo logo-nodezoo"></a>
       </header>
     )
   }


### PR DESCRIPTION
Change header logo to use relative path, allows it to work for the beta site and local testing. Resolves https://github.com/nodezoo/nodezoo-web/issues/109